### PR TITLE
Revert "upgrade dependencies requiring node-sass to latest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "2.6.0",
+    "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.5",
     "ember-cli-app-version": "0.4.0",
     "ember-cli-autoprefixer": "0.4.1",
@@ -58,9 +58,9 @@
     "flag"
   ],
   "dependencies": {
-    "ember-cli-babel": "6.8.1",
-    "ember-cli-htmlbars": "2.0.2",
-    "ember-cli-sass": "7.0.0"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-sass": "5.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Reverts digitalocean/ember-intl-tel-input#1

Running into the same issues after upgrading dependencies as https://github.com/justin-lau/ember-intl-tel-input/issues/6.

@magicgrl111 @brianarn @jennazee
